### PR TITLE
[update]

### DIFF
--- a/inc/ctl/mainwindow.h
+++ b/inc/ctl/mainwindow.h
@@ -72,6 +72,7 @@ private slots:
     void on_dfs_menu_paste_2_triggered();
     void on_treeW_plugin_itemDoubleClicked(QTreeWidgetItem *item, int column);
     void send_msg(QByteArray msg);
+    void sortHeader(int index);
 
 private:
     void init_ctl(void);/* 初始化界面的控件 */
@@ -81,15 +82,15 @@ private:
 private:
     Ui::MainWindow *ui;
     seimey_serial *c_Seimey_Serial = new seimey_serial(this);
-    seimey_qwchse *c_Seimey_Qwchse = NULL;
-    seimey_setting *c_Seimey_Setting = NULL;
+    seimey_qwchse *c_Seimey_Qwchse = nullptr;
+    seimey_setting *c_Seimey_Setting = nullptr;
     seimey_plugin *c_Seimey_Plugin = new seimey_plugin(this);
-    QTimer *finsh_timerID = new QTimer(this);;
+    QTimer *finsh_timerID = new QTimer(this);
     seimey_data *c_Seimey_Data = new seimey_data(this);
     seimey_finsh *c_Seimey_Finsh = new seimey_finsh(this);
     seimey_dfs *c_Seimey_Dfs = new seimey_dfs(this);
     QMenu *dfs_menu = new QMenu(this);
-    QTreeWidgetItem *treew_dfs_MenuRequested = NULL;
+    QTreeWidgetItem *treew_dfs_MenuRequested = nullptr;
     QString dfs_clipboard;
     struct
     {

--- a/inc/ctl/seimey_qwchse.h
+++ b/inc/ctl/seimey_qwchse.h
@@ -39,7 +39,7 @@ class seimey_qwchse_Label : public QLabel
 {
     Q_OBJECT
 public:
-    explicit seimey_qwchse_Label(QWidget *parent = 0);
+    explicit seimey_qwchse_Label(QWidget *parent = nullptr);
     ~seimey_qwchse_Label();
 
 protected:

--- a/inc/seimey_finsh.h
+++ b/inc/seimey_finsh.h
@@ -16,8 +16,10 @@
 #include "progresswater.h"
 #include <QLabel>
 #include <QTreeWidgetItem>
+#include <QTableWidgetItem>
 #include <QTimer>
 #include <QLineEdit>
+
 #include "seimey_serial.h"
 class seimey_finsh : public QObject
 {
@@ -26,7 +28,7 @@ public:
     explicit seimey_finsh(QObject *parent = nullptr);
 public:
     void handle(QString msg);/* 任务管理器的控制函数 */
-    void thread(seimey_serial *Serial, QTreeWidget *obj); /* finsh Thread */
+    void thread(seimey_serial *Serial, QTableWidget *obj); /* finsh Thread */
     void device(seimey_serial *Serial, QTreeWidget *obj); /* finsh Device */
     void time(seimey_serial *Serial, QTreeWidget *obj, QLineEdit *line);
     void mem_pool(seimey_serial *Serial, QTreeWidget *obj);
@@ -60,7 +62,7 @@ private:
     uint8_t event;
     QTimer *timer = new QTimer(this);
     QStringList msg_list;
-    QTreeWidget *tree_thread;
+    QTableWidget *tree_thread;
     QTreeWidget *tree_device;
     QTreeWidget *tree_timer;
     QTreeWidget *tree_mem_pool;

--- a/inc/seimey_plugin.h
+++ b/inc/seimey_plugin.h
@@ -27,7 +27,7 @@ private:
     void loader_plugin(QObject *obj);
     void loader_gdut_fsae_plugin(QObject *obj);
 private:
-    gdut_fsae_interface *_pgdut_fsae_interface = NULL;
+    gdut_fsae_interface *_pgdut_fsae_interface = nullptr;
 
     QStringList plugin_list =
     {

--- a/sdk/navlabel.h
+++ b/sdk/navlabel.h
@@ -56,7 +56,7 @@ public:
         TrianglePosition_Bottom = 3 //底部
     };
 
-    explicit NavLabel(QWidget *parent = 0);
+    explicit NavLabel(QWidget *parent = nullptr);
 
 protected:
     void mousePressEvent(QMouseEvent *);

--- a/sdk/progresswater.h
+++ b/sdk/progresswater.h
@@ -62,7 +62,7 @@ public:
         PercentStyle_Cylinder = 3       //圆柱风格
     };
 
-    explicit ProgressWater(QWidget *parent = 0);
+    explicit ProgressWater(QWidget *parent = nullptr);
     ~ProgressWater();
 
 protected:

--- a/src/ctl/mainwindow.cpp
+++ b/src/ctl/mainwindow.cpp
@@ -65,12 +65,14 @@ void MainWindow::init_ctl(void)
     {
         if (ui->tabW_main->currentIndex() == 0)
         {
-            finsh_timerID->setInterval(setting.timed_refresh * 1000);
+            finsh_timerID->setInterval(static_cast<int>(setting.timed_refresh * 1000));
             finsh_timerID->start();
         }
     }
     QHeaderView *head = ui->treeW_file_mannage->header();
     head->setSectionResizeMode(QHeaderView::ResizeToContents);
+
+    connect(ui->treeW_finsh_thread->horizontalHeader(),&QHeaderView::sectionClicked, this,&MainWindow::sortHeader);
 }
 /*
  *  用来初始化一些connect函数
@@ -90,7 +92,7 @@ void MainWindow::on_menu_setting_serial_setting_triggered()
     connect(c_Seimey_Qwchse, &seimey_qwchse::window_close, [ = ]()
     {
         on_menu_setting_serial_link_triggered();
-        c_Seimey_Qwchse = NULL;
+        c_Seimey_Qwchse = nullptr;
     });
     c_Seimey_Qwchse->show();
 }
@@ -142,7 +144,7 @@ void MainWindow::on_menu_setting_preference_triggered()
         {
             if (ui->tabW_main->currentIndex() == 0)
             {
-                finsh_timerID->setInterval(setting.timed_refresh * 1000);
+                finsh_timerID->setInterval(static_cast<int>(setting.timed_refresh * 1000));
                 finsh_timerID->start();
             }
         }
@@ -150,7 +152,7 @@ void MainWindow::on_menu_setting_preference_triggered()
         {
             finsh_timerID->stop();
         }
-        c_Seimey_Setting = NULL;
+        c_Seimey_Setting = nullptr;
     });
     c_Seimey_Setting->show();
 }
@@ -170,7 +172,7 @@ void MainWindow::serial_data_coming(QByteArray msg)
     {
         c_Seimey_Data->save_Serial_Data(msg);
     }
-    if (c_Seimey_Plugin != NULL)
+    if (c_Seimey_Plugin != nullptr)
     {
         c_Seimey_Plugin->rec_msg(msg);
     }
@@ -342,7 +344,7 @@ void MainWindow::on_tabW_main_tabBarDoubleClicked(int index)
         setting.timed_refresh = c_Seimey_Data->get_Timed_Refresh_Time();
         if (setting.timed_refresh > 0)
         {
-            finsh_timerID->setInterval(setting.timed_refresh * 1000);
+            finsh_timerID->setInterval(static_cast<int>(setting.timed_refresh * 1000));
             finsh_timerID->start();
         }
         else
@@ -424,7 +426,7 @@ void MainWindow::on_dfs_menu_open_triggered()
     if (treew_dfs_MenuRequested)
     {
         c_Seimey_Dfs->servant(c_Seimey_Serial, treew_dfs_MenuRequested);
-        treew_dfs_MenuRequested = NULL;
+        treew_dfs_MenuRequested = nullptr;
     }
 }
 
@@ -452,7 +454,7 @@ void MainWindow::on_dfs_menu_mkdir_triggered()
                 msg.replace(QString(" "), QString("_"));
             }
             c_Seimey_Dfs->mkdir(c_Seimey_Serial, msg, treew_dfs_MenuRequested);
-            treew_dfs_MenuRequested = NULL;
+            treew_dfs_MenuRequested = nullptr;
         }
     }
 }
@@ -482,12 +484,12 @@ void MainWindow::on_dfs_menu_echo_triggered()
             QString msg = filedata->text();
             if (name.isEmpty())
             {
-                QMessageBox::warning(NULL, "警告", "文件名未输入");
+                QMessageBox::warning(nullptr, "警告", "文件名未输入");
                 return;
             }
             else if (msg.isEmpty())
             {
-                QMessageBox::warning(NULL, "警告", "文件内容未输入");
+                QMessageBox::warning(nullptr, "警告", "文件内容未输入");
                 return;
             }
 
@@ -502,7 +504,7 @@ void MainWindow::on_dfs_menu_echo_triggered()
                     msg.replace(QString(" "), QString("_"));
                 }
                 c_Seimey_Dfs->echo(c_Seimey_Serial, name, msg, treew_dfs_MenuRequested);
-                treew_dfs_MenuRequested = NULL;
+                treew_dfs_MenuRequested = nullptr;
             }
         }
     }
@@ -513,7 +515,7 @@ void MainWindow::on_dfs_menu_rm_triggered()
     if (treew_dfs_MenuRequested)
     {
         c_Seimey_Dfs->rm(c_Seimey_Serial, treew_dfs_MenuRequested, ui->treeW_file_mannage);
-        treew_dfs_MenuRequested = NULL;
+        treew_dfs_MenuRequested = nullptr;
     }
 }
 
@@ -522,7 +524,7 @@ void MainWindow::on_dfs_menu_copy_triggered()
     if (treew_dfs_MenuRequested)
     {
         dfs_clipboard = treew_dfs_MenuRequested->whatsThis(0) + treew_dfs_MenuRequested->text(0);
-        treew_dfs_MenuRequested = NULL;
+        treew_dfs_MenuRequested = nullptr;
     }
 }
 
@@ -537,7 +539,7 @@ void MainWindow::on_dfs_menu_paste_triggered()
         }
         c_Seimey_Dfs->cp(c_Seimey_Serial, dfs_clipboard, pur, treew_dfs_MenuRequested, ui->treeW_file_mannage);
         dfs_clipboard.clear();
-        treew_dfs_MenuRequested = NULL;
+        treew_dfs_MenuRequested = nullptr;
     }
 }
 
@@ -588,12 +590,12 @@ void MainWindow::on_dfs_menu_echo_2_triggered()
         QString msg = filedata->text();
         if (name.isEmpty())
         {
-            QMessageBox::warning(NULL, "警告", "文件名未输入");
+            QMessageBox::warning(nullptr, "警告", "文件名未输入");
             return;
         }
         else if (msg.isEmpty())
         {
-            QMessageBox::warning(NULL, "警告", "文件内容未输入");
+            QMessageBox::warning(nullptr, "警告", "文件内容未输入");
             return;
         }
 
@@ -629,4 +631,9 @@ void MainWindow::on_treeW_plugin_itemDoubleClicked(QTreeWidgetItem *item, int co
 void MainWindow::send_msg(QByteArray msg)
 {
     c_Seimey_Serial->send_data(msg);
+}
+
+void MainWindow::sortHeader(int index)
+{
+    ui->treeW_finsh_thread->sortItems(index, Qt::AscendingOrder);
 }

--- a/src/ctl/seimey_qwchse.cpp
+++ b/src/ctl/seimey_qwchse.cpp
@@ -59,7 +59,7 @@ void seimey_qwchse::closeEvent(QCloseEvent *event)
 
     /* write file bom and json data */
     unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-    serial_file.write((char *)bom, sizeof(bom));
+    serial_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
     QTextStream in(&serial_file);
     in.setCodec("UTF-8");
     in << QString(serial_json.toJson());

--- a/src/ctl/seimey_setting.cpp
+++ b/src/ctl/seimey_setting.cpp
@@ -39,7 +39,7 @@ void seimey_setting::closeEvent(QCloseEvent *event)
     setting_file.open(QIODevice::ReadWrite | QIODevice::Truncate);
 
     unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-    setting_file.write((char *)bom, sizeof(bom));
+    setting_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
     QTextStream in(&setting_file);
     in.setCodec("UTF-8");
     in << QString(setting_json.toJson());

--- a/src/seimey_data.cpp
+++ b/src/seimey_data.cpp
@@ -41,7 +41,7 @@ void seimey_data::ceate_Serial(void)
     {
         serial_set_file.open(QIODevice::Append | QIODevice::Text);
         unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-        serial_set_file.write((char *)bom, sizeof(bom));
+        serial_set_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
         QTextStream in(&serial_set_file);
         in.setCodec("UTF-8");
         in << "{\n";
@@ -62,7 +62,7 @@ void seimey_data::ceate_Serial(void)
     {
         serial_data_file.open(QIODevice::Append | QIODevice::Text);
         unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-        serial_data_file.write((char *)bom, sizeof(bom));
+        serial_data_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
         QTextStream in(&serial_data_file);
         in.setCodec("UTF-8");
         in << QString("# 串口数据\n");
@@ -89,7 +89,7 @@ void seimey_data::ceate_Log(void)
     {
         log_file.open(QIODevice::Append | QIODevice::Text);
         unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-        log_file.write((char *)bom, sizeof(bom));
+        log_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
         log_file.flush();
         log_file.close();
     }
@@ -113,7 +113,7 @@ void seimey_data::ceate_Setting(void)
     {
         setting_file.open(QIODevice::Append | QIODevice::Text);
         unsigned char bom[] = {0xEF, 0xBB, 0xBF};
-        setting_file.write((char *)bom, sizeof(bom));
+        setting_file.write(static_cast<char*>(static_cast<void*>(bom)), sizeof(bom));
         QTextStream in(&setting_file);
         in.setCodec("UTF-8");
         in << "{\n";

--- a/src/seimey_dfs.cpp
+++ b/src/seimey_dfs.cpp
@@ -256,7 +256,7 @@ void seimey_dfs::rm(seimey_serial *Serial, QTreeWidgetItem *obj1, QTreeWidget *o
     Serial->send_data((char *)"\r\n");
     sleep(500);
 
-    if (obj1->parent() != NULL)
+    if (obj1->parent() != nullptr)
     {
         tree_dfs_item = obj1->parent();
         servant(Serial, tree_dfs_item);
@@ -277,7 +277,7 @@ void seimey_dfs::cp(seimey_serial *Serial, QString src, QString pur, QTreeWidget
     Serial->send_data((char *)pur_byte.data());
     Serial->send_data((char *)"\r\n");
     sleep(500);
-    if (obj1->parent() != NULL)
+    if (obj1->parent() != nullptr)
     {
         tree_dfs_item = obj1->parent();
         servant(Serial, tree_dfs_item);
@@ -318,12 +318,12 @@ void seimey_dfs::ctl_cat(QStringList *list)
                 if (index == msg.length() - head.length())
                 {
                     msg = msg.left(index);
-                    if (c_Seimey_text == NULL)
+                    if (c_Seimey_text == nullptr)
                     {
                         c_Seimey_text = new seimey_text();
                         connect(c_Seimey_text, &seimey_text::window_Close, [ = ]()
                         {
-                            c_Seimey_text = NULL;
+                            c_Seimey_text = nullptr;
                         });
                         c_Seimey_text->show();
                         c_Seimey_text->show_text(msg);

--- a/src/seimey_plugin.cpp
+++ b/src/seimey_plugin.cpp
@@ -29,7 +29,7 @@ void seimey_plugin::set_plugin(QTreeWidget *obj)
 
 void seimey_plugin::rec_msg(QByteArray msg)
 {
-    if (_pgdut_fsae_interface != NULL)
+    if (_pgdut_fsae_interface != nullptr)
     {
         _pgdut_fsae_interface->rec_msg(msg);
     }
@@ -75,10 +75,10 @@ void seimey_plugin::loader_plugin(QObject *obj)
 }
 void seimey_plugin::loader_gdut_fsae_plugin(QObject *obj)
 {
-    if (_pgdut_fsae_interface == NULL)
+    if (_pgdut_fsae_interface == nullptr)
     {
         _pgdut_fsae_interface = qobject_cast<gdut_fsae_interface *>(obj);
-        if (_pgdut_fsae_interface != NULL)
+        if (_pgdut_fsae_interface != nullptr)
         {
             connect(obj, SIGNAL(plugin_close(QString)), this, SLOT(close_event_collect(QString)), Qt::UniqueConnection);
             connect(obj, SIGNAL(send_msg(QByteArray)), this, SLOT(forward_msg(QByteArray)), Qt::UniqueConnection);
@@ -94,7 +94,7 @@ void seimey_plugin::close_event_collect(QString msg)
         switch (index)
         {
         case PLUGIN_GDUT_FSAE:
-            _pgdut_fsae_interface = NULL;
+            _pgdut_fsae_interface = nullptr;
             break;
         }
     }

--- a/src/seimey_serial.cpp
+++ b/src/seimey_serial.cpp
@@ -187,19 +187,19 @@ void seimey_serial::serial_error(QSerialPort::SerialPortError error)
 {
     if (error == QSerialPort::DeviceNotFoundError)
     {
-        QMessageBox::warning(NULL, "警告", "未知的设备，请刷新设备表");
+        QMessageBox::warning(nullptr, "警告", "未知的设备，请刷新设备表");
     }
     else if (error == QSerialPort::OpenError)
     {
-        QMessageBox::warning(NULL, "警告", "重复打开串口设备");
+        QMessageBox::warning(nullptr, "警告", "重复打开串口设备");
     }
     else if (error == QSerialPort::PermissionError)
     {
-        QMessageBox::warning(NULL, "警告", "此串口已被其他应用程序使用");
+        QMessageBox::warning(nullptr, "警告", "此串口已被其他应用程序使用");
     }
     else if (error == QSerialPort::WriteError)
     {
-        QMessageBox::warning(NULL, "警告", "串口写入错误");
+        QMessageBox::warning(nullptr, "警告", "串口写入错误");
     }
 }
 

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -25,7 +25,7 @@
        <string/>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="task_manager">
        <attribute name="icon">
@@ -54,13 +54,43 @@
            </attribute>
            <layout class="QGridLayout" name="gridLayout_7">
             <item row="0" column="0">
-             <widget class="QTreeWidget" name="treeW_finsh_thread">
+             <widget class="QTableWidget" name="treeW_finsh_thread">
               <property name="styleSheet">
                <string notr="true"/>
               </property>
               <property name="frameShape">
                <enum>QFrame::NoFrame</enum>
               </property>
+              <row>
+               <property name="text">
+                <string>1</string>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string>2</string>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string>3</string>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string>4</string>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string>5</string>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string>6</string>
+               </property>
+              </row>
               <column>
                <property name="text">
                 <string>线程</string>
@@ -78,7 +108,7 @@
               </column>
               <column>
                <property name="text">
-                <string>栈位置</string>
+                <string>栈顶位置</string>
                </property>
               </column>
               <column>
@@ -88,7 +118,7 @@
               </column>
               <column>
                <property name="text">
-                <string>最大使用</string>
+                <string>使用率</string>
                </property>
               </column>
               <column>
@@ -136,12 +166,12 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>171</width>
-                 <height>149</height>
+                 <width>210</width>
+                 <height>210</height>
                 </rect>
                </property>
                <layout class="QGridLayout" name="gridLayout_10">
-                <item row="0" column="0">
+                <item row="8" column="0">
                  <widget class="QCommandLinkButton" name="comdLB_mem_pool">
                   <property name="minimumSize">
                    <size>
@@ -166,18 +196,18 @@
                    <bool>true</bool>
                   </property>
                   <property name="checked">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="0">
-                 <widget class="QCommandLinkButton" name="comdLB_mem_heap">
+                <item row="6" column="0">
+                 <widget class="QCommandLinkButton" name="comdLB_mem_free">
                   <property name="text">
-                   <string>内存堆</string>
+                   <string>动态内存</string>
                   </property>
                   <property name="icon">
                    <iconset resource="../seimey.qrc">
-                    <normaloff>:/icon/qrc/icon/memheap.png</normaloff>:/icon/qrc/icon/memheap.png</iconset>
+                    <normaloff>:/icon/qrc/icon/memory.png</normaloff>:/icon/qrc/icon/memory.png</iconset>
                   </property>
                   <property name="iconSize">
                    <size>
@@ -188,16 +218,19 @@
                   <property name="checkable">
                    <bool>true</bool>
                   </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
-                 <widget class="QCommandLinkButton" name="comdLB_mem_free">
+                <item row="7" column="0">
+                 <widget class="QCommandLinkButton" name="comdLB_mem_heap">
                   <property name="text">
-                   <string>动态内存</string>
+                   <string>内存堆</string>
                   </property>
                   <property name="icon">
                    <iconset resource="../seimey.qrc">
-                    <normaloff>:/icon/qrc/icon/memory.png</normaloff>:/icon/qrc/icon/memory.png</iconset>
+                    <normaloff>:/icon/qrc/icon/memheap.png</normaloff>:/icon/qrc/icon/memheap.png</iconset>
                   </property>
                   <property name="iconSize">
                    <size>
@@ -224,7 +257,7 @@
             <item row="0" column="2" rowspan="2">
              <widget class="QStackedWidget" name="stackedW_property">
               <property name="currentIndex">
-               <number>0</number>
+               <number>2</number>
               </property>
               <widget class="QWidget" name="page_5">
                <layout class="QGridLayout" name="gridLayout_16">
@@ -329,9 +362,6 @@
                   </property>
                   <property name="reverse">
                    <bool>false</bool>
-                  </property>
-                  <property name="percentStyle">
-                   <enum>ProgressWater::PercentStyle_Circle</enum>
                   </property>
                  </widget>
                 </item>
@@ -522,8 +552,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>171</width>
-                 <height>149</height>
+                 <width>210</width>
+                 <height>210</height>
                 </rect>
                </property>
                <layout class="QGridLayout" name="gridLayout_3">
@@ -752,8 +782,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>171</width>
-                 <height>104</height>
+                 <width>210</width>
+                 <height>144</height>
                 </rect>
                </property>
                <layout class="QGridLayout" name="gridLayout_5">
@@ -1230,7 +1260,7 @@
      <x>0</x>
      <y>0</y>
      <width>999</width>
-     <height>26</height>
+     <height>23</height>
     </rect>
    </property>
    <property name="defaultUp">


### PR DESCRIPTION
1. 修复导致编译器警告的语法
2. 调整内存按钮的顺序，因为内存池使用较少，动态内存使用较多，所以要把他排第一
3. 调整线程显示部分的显示容器，从 treewidget 切换到 tablewidget。目的是使表头可以点击，这样就可以实现点击表头之后能对线程的优先级进行排序
4. 粗略的定义了实现排序的槽函数，目前只能对比槽函数的第一个字母来进行排序，而且会立刻被新的数据冲掉，这个是后续需要重点完善的部分